### PR TITLE
install(nyz): add install package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,6 @@ from setuptools import setup
 
 setup(name='gym_hybrid',
       version='0.0.1',
-      install_requires=['gym', 'numpy']
+      packages=['gym_hybrid'],
+      install_requires=['gym', 'numpy'],
 )


### PR DESCRIPTION
add package information in `setup.py`, otherwise, there is no any python file after `pip install .`